### PR TITLE
IMPROVEMENT: Add note for JS and CSS Files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,8 @@ On Divio Cloud this can be done through the Addons configuration.
 a `javascript configuration file <https://github.com/divio/djangocms-boilerplate-webpack/blob/master/static/js/addons/ckeditor.wysiwyg.js#L68>`_
 to ``style_set``.
 
+django CMS Icon does not add the styles or javascript files to your frontend, these need to be added at your discretion.
+
 
 Configuration
 -------------


### PR DESCRIPTION
It's the same behavior as with the djangocms-bootstrap4 package, the icons are only displayed correctly if you download FontAwesome from the website and include it in your project.