### PR TITLE
fix: Updated mention of fontawesome 4 being default [#38]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,15 +75,15 @@ setting::
 Web Font Icons
 ##############
 
-The django CMS Icon plugin ships with **Font Awesome 4 as default**. This can
+The django CMS Icon plugin ships with **Font Awesome 5 as default**. This can
 be changed by overriding the following setting::
 
     DJANGOCMS_ICON_SETS = [
-        ('fontawesome4', 'fa', 'Font Awesome 4'),
+        ('fontawesome5regular', 'far', 'Font Awesome 5 Regular', 'lastest'),
+        ('fontawesome5solid', 'fas', 'Font Awesome 5 Solid', 'lastest'),
+        ('fontawesome5brands', 'fab', 'Font Awesome 5 Brands', 'lastest'),
     ]
 
-To use Font Awesome 5 in the above example; see the options below form the
-``DJANGOCMS_ICON_SETS`` listed.
 
 In addition **you need to load** the resources for your fonts in
 ``/admin/djangocms_icon/includes/assets.html``. Add this file to your project
@@ -95,7 +95,6 @@ out of the box. You can also add multiple font sets like this::
     DJANGOCMS_ICON_SETS = [
         ('elusiveicon', 'el', 'Elusive Icons'),
         ('flagicon', 'flag-icon', 'Flag Icons'),
-        ('fontawesome4', 'fa', 'Font Awesome 4'),
         ('fontawesome5regular', 'far', 'Font Awesome 5 Regular'),
         ('fontawesome5solid', 'fas', 'Font Awesome 5 Solid'),
         ('fontawesome5brands', 'fab', 'Font Awesome 5 Brands'),


### PR DESCRIPTION
## Description

Fixes issue raised with README mentioning font awesome 4 is default when infact it is now version 5.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #38

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
